### PR TITLE
GSFEKF: fix filter weights initialization

### DIFF
--- a/initialiseGSFEKF.m
+++ b/initialiseGSFEKF.m
@@ -15,6 +15,6 @@ P_GSF           = zeros(3,3,numberOfModels);
 % initialise states with yaw evenly spaced and symmetrical about 0
 for i = 1:N
     X_GSF(:,i)      = [Vn_0;Ve_0;-pi+increment/2 + (i-1)*increment];
-    P_GSF(:,:,1)    = P_Filter;
+    P_GSF(:,:,i)    = P_Filter;
     w_GSF(i)        = 1/(numberOfModels);
 end


### PR DESCRIPTION
The following plots are the state uncertainties of all the 7 filter cores in the Gaussian sum filter

**Velocity north variance**
![image](https://user-images.githubusercontent.com/7795133/69708684-5873ab80-10fc-11ea-997b-7428990cb395.png)

**Velocity east variance**
![image](https://user-images.githubusercontent.com/7795133/69708687-5b6e9c00-10fc-11ea-9115-2faebccb6c6a.png)

**Yaw angle variance**
![image](https://user-images.githubusercontent.com/7795133/69708690-5d385f80-10fc-11ea-9f0a-22841e3cfae5.png)

After the change has been applied from this PR
**Velocity north variance**
![image](https://user-images.githubusercontent.com/7795133/69708791-83f69600-10fc-11ea-83ff-6f1567565e7b.png)

**Yaw angle variance**
![image](https://user-images.githubusercontent.com/7795133/69708805-8bb63a80-10fc-11ea-95ef-914356507ece.png)

The difference in the output from the test dataset is small because the movement of the vehicle does not start until the yaw variance have increased quite a lot from zero

**Before PR**
![image](https://user-images.githubusercontent.com/7795133/69708967-d59f2080-10fc-11ea-8ca8-b67ff2f9e17c.png)

**After PR**
![image](https://user-images.githubusercontent.com/7795133/69708991-dcc62e80-10fc-11ea-8421-457b4a963216.png)
